### PR TITLE
Fix: Odd behaviour in social links in Teams page

### DIFF
--- a/src/Pages/Team/Cluster.js
+++ b/src/Pages/Team/Cluster.js
@@ -54,12 +54,12 @@ const Cluster = (props) => {
       />
       <p>{person.name}</p>
       <div className="social">
-        <a href={person.github} target="_blank">
+        {person.github && <a href={person.github} target="_blank">
           <img src={git} />
-        </a>
-        <a href={person.linkedin} target="_blank">
+        </a>}
+        {person.linkedin && <a href={person.linkedin} target="_blank">
           <img src={linkedin} />
-        </a>
+        </a>}
       </div>
     </div>
   ));

--- a/src/Pages/Team/cluster.css
+++ b/src/Pages/Team/cluster.css
@@ -14,6 +14,10 @@
   }
 }
 
+.social {
+  min-height: 100px;
+}
+
 .social img {
   border-radius: 0;
   width: 24px;


### PR DESCRIPTION
Fixed the page reload issue when clicked on social links which don't have any links